### PR TITLE
Add handlers to the kubernetes-proxy role

### DIFF
--- a/roles/kubernetes-proxy/handlers/main.yml
+++ b/roles/kubernetes-proxy/handlers/main.yml
@@ -1,0 +1,11 @@
+- name: Restart haproxy
+  listen: restart-haproxy
+  ansible.builtin.systemd:
+    name: haproxy
+    state: restarted
+
+- name: Restart keepalived
+  listen: restart-keepalived
+  ansible.builtin.systemd:
+    name: keepalived
+    state: restarted

--- a/roles/kubernetes-proxy/tasks/main.yml
+++ b/roles/kubernetes-proxy/tasks/main.yml
@@ -1,10 +1,12 @@
 - name: Install haproxy
-  ansible.builtin.apt:
+  notify: restart-haproxy
+  ansible.builtin.package:
     name:
     - haproxy
     state: present
 
 - name: Copy haproxy.cfg
+  notify: restart-haproxy
   ansible.builtin.template:
     src: haproxy.cfg.j2
     dest: /etc/haproxy/haproxy.cfg
@@ -12,25 +14,27 @@
     group: root
     mode: '0644'
 
-- name: Restart haproxy
-  ansible.builtin.systemd:
+- name: Enable haproxy
+  ansible.builtin.systemd_service:
+    enabled: true
     name: haproxy
-    state: restarted
 
 - name: Install keepalived
-  ansible.builtin.apt:
+  notify: restart-keepalived
+  ansible.builtin.package:
     name:
     - keepalived
     state: present
 
-- name: "Copy keepalived configuration"
+- name: Copy keepalived.conf
+  notify: restart-keepalived
   ansible.builtin.template:
     src: keepalived.conf.j2
     dest: /etc/keepalived/keepalived.conf
     owner: root
     mode: 0644
 
-- name: Restart keepalived
-  ansible.builtin.systemd:
+- name: Enable keepalived
+  ansible.builtin.systemd_service:
+    enabled: true
     name: keepalived
-    state: restarted


### PR DESCRIPTION
- Only restart haproxy or keepalived if needed
- Set haproxy and keepalived to enabled if they weren't
- Use the generic package installer to support non-apt based distros
- Minor name and quoting consistency changes